### PR TITLE
Add tests in Docker image for runtime testing

### DIFF
--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -25,4 +25,7 @@ ADD ["Instances/", "C:/ProgramData/Microsoft/VisualStudio/Packages/_Instances/"]
 RUN $ErrorActionPreference = 'Stop' ; \
     New-Item -Path C:\VS\Community, C:\VS\Enterprise, C:\VS\Professional, C:\BuildTools -Type Directory | Out-Null
 
+# Copy tests
+ADD ["Tests", "C:/Tests"]
+
 ENTRYPOINT ["powershell.exe", "-ExecutionPolicy", "Unrestricted"]

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -1,0 +1,28 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+
+# Require .NET Framework
+FROM microsoft/windowsservercore
+
+ENV API_VERSION="1.3.269-rc"
+
+# Download and register current query APIs
+SHELL ["powershell.exe", "-ExecutionPolicy", "Bypass", "-Command"]
+RUN $ErrorActionPreference = 'Stop' ; \
+    New-Item -Path C:\Downloads -Type Directory | Out-Null ; \
+    Invoke-WebRequest -Uri "https://www.nuget.org/api/v2/package/Microsoft.VisualStudio.Setup.Configuration.Native/${env:API_VERSION}" -OutFile C:\Downloads\Microsoft.VisualStudio.Setup.Configuration.Native.zip ; \
+    Expand-Archive -Path C:\Downloads\Microsoft.VisualStudio.Setup.Configuration.Native.zip -DestinationPath C:\Downloads\Microsoft.VisualStudio.Setup.Configuration.Native ; \
+    C:\Windows\System32\regsvr32.exe /s C:\Downloads\Microsoft.VisualStudio.Setup.Configuration.Native\tools\x64\Microsoft.VisualStudio.Setup.Configuration.Native.dll ; \
+    C:\Windows\SysWOW64\regsvr32.exe /s C:\Downloads\Microsoft.VisualStudio.Setup.Configuration.Native\tools\x86\Microsoft.VisualStudio.Setup.Configuration.Native.dll
+
+# Install latest version of Pester for integration testing
+RUN $ErrorActionPreference = 'Stop' ; \
+    Install-PackageProvider -Name nuget -MinimumVersion 2.8.5.201 -Force ; \
+    Install-Module -Name Pester -Scope CurrentUser -SkipPublisherCheck -Force
+
+# Copy test instance data and set up directories
+ADD ["Instances/", "C:/ProgramData/Microsoft/VisualStudio/Packages/_Instances/"]
+RUN $ErrorActionPreference = 'Stop' ; \
+    New-Item -Path C:\VS\Community, C:\VS\Enterprise, C:\VS\Professional, C:\BuildTools -Type Directory | Out-Null
+
+ENTRYPOINT ["powershell.exe", "-ExecutionPolicy", "Unrestricted"]

--- a/test/docker/Instances/1/state.json
+++ b/test/docker/Instances/1/state.json
@@ -1,0 +1,57 @@
+{
+    "installationName": "VisualStudio/public.d15rel/15.0.26116.0",
+    "installationVersion": "15.0.26116.0",
+    "installationPath": "C:\\VS\\Community",
+    "installDate": "2017-01-17T03:00:00Z",
+    "product": {
+        "id": "Microsoft.VisualStudio.Product.Community",
+        "version": "15.0.26116.0",
+        "type": "Product"
+    },
+    "localizedResources": [
+        {
+            "language": "en-us",
+            "title": "Visual Studio Community 2017",
+            "description": "Free, fully-featured IDE for students, open-source and individual developers"
+        },
+        {
+            "language": "de-de",
+            "title": "Visual Studio Community 2017",
+            "description": "Kostenlose, voll funktionsfähige IDE für Studenten, Open Source- und einzelne Entwickler."
+        }
+    ],
+    "launchParams": {
+        "fileName": "Common7\\IDE\\devenv.exe"
+    },
+    "enginePath": "C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\resources\\app\\ServiceHub\\Services\\Microsoft.VisualStudio.Setup.Service",
+    "selectedPackages": [
+        {
+            "id": "Microsoft.VisualStudio.Product.Community",
+            "version": "15.0.26116.0",
+            "type": "Product",
+            "selectedState": "IndividuallySelected"
+        }
+    ],
+    "packages": [
+        {
+			"id": "Microsoft.VisualStudio.Workload.ManagedDesktop",
+			"version": "15.0.26116.0",
+			"type": "Workload"
+        },
+        {
+			"id": "Microsoft.VisualStudio.Workload.CoreEditor",
+			"version": "15.0.26116.0",
+			"type": "Workload"
+        },
+        {
+			"id": "Microsoft.VisualStudio.Branding.Community",
+			"version": "15.0.26116.0",
+			"type": "Vsix"
+        },
+        {
+            "id": "Microsoft.VisualStudio.Product.Community",
+            "version": "15.0.26116.0",
+            "type": "Product"
+        }
+    ]
+}

--- a/test/docker/Instances/2/state.json
+++ b/test/docker/Instances/2/state.json
@@ -1,0 +1,74 @@
+{
+    "installationName": "VisualStudio/public.d15rel/15.0.26117.0",
+    "installationVersion": "15.0.26117.0",
+    "installationPath": "C:\\VS\\Enterprise",
+    "installDate": "2017-01-18T03:15:00Z",
+    "product": {
+        "id": "Microsoft.VisualStudio.Product.Enterprise",
+        "version": "15.0.26117.0",
+        "type": "Product"
+    },
+    "localizedResources": [
+        {
+            "language": "en-us",
+            "title": "Visual Studio Enterprise 2017",
+            "description": "Microsoft DevOps solution for productivity and coordination across teams of any size"
+        },
+        {
+            "language": "de-de",
+            "title": "Visual Studio Enterprise 2017",
+            "description": "Microsoft DevOps-Lösung für Produktivität und Koordination von Teams beliebiger Größe"
+        }
+    ],
+    "launchParams": {
+        "fileName": "Common7\\IDE\\devenv.exe"
+    },
+    "enginePath": "C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\resources\\app\\ServiceHub\\Services\\Microsoft.VisualStudio.Setup.Service",
+    "selectedPackages": [
+        {
+            "id": "Microsoft.VisualStudio.Product.Enterprise",
+            "version": "15.0.26117.0",
+            "type": "Product",
+            "selectedState": "IndividuallySelected"
+        }
+    ],
+    "packages": [
+        {
+			"id": "Microsoft.VisualStudio.Workload.ManagedDesktop",
+			"version": "15.0.26117.0",
+			"type": "Workload"
+        },
+        {
+			"id": "Microsoft.VisualStudio.Workload.NativeDesktop",
+			"version": "15.0.26117.0",
+			"type": "Workload"
+        },
+        {
+			"id": "Microsoft.VisualStudio.Workload.CoreEditor",
+			"version": "15.0.26117.0",
+			"type": "Workload"
+        },
+        {
+			"id": "Microsoft.VisualStudio.Branding.Enterprise",
+			"version": "15.0.26117.0",
+			"type": "Vsix"
+        },
+        {
+            "id": "Microsoft.VisualStudio.Product.Enterprise",
+            "version": "15.0.26117.0",
+            "type": "Product"
+        }
+    ],
+    "errors": {
+        "errorLogFilePath": "C:\\TEMP\\dd_setup_201601180315_errors.log",
+        "failedPackages": [
+            {
+                "id": "Microsoft.VisualStudio.Workload.Office",
+                "version": "15.0.26009.0",
+                "type": "Workload",
+                "logFilePath": "C:\\TEMP\\dd_setup_201601180315_003_Microsoft.VisualStudio.Workload.Office_errors.log",
+                "description": "Failed to install Microsoft.VisualStudio.Workload.Office"
+            }
+        ]
+    }
+}

--- a/test/docker/Instances/3/state.json
+++ b/test/docker/Instances/3/state.json
@@ -1,0 +1,57 @@
+{
+    "installationName": "VisualStudio/public.d15rel/15.0.26117.0",
+    "installationVersion": "15.0.26117.0",
+    "installationPath": "C:\\VS\\Professional",
+    "installDate": "2017-01-18T03:30:00Z",
+    "product": {
+        "id": "Microsoft.VisualStudio.Product.Professional",
+        "version": "15.0.26117.0",
+        "type": "Product"
+    },
+    "localizedResources": [
+        {
+            "language": "en-us",
+            "title": "Visual Studio Professional 2017",
+            "description": "Professional developer tools and services for small teams"
+        },
+        {
+            "language": "de-de",
+            "title": "Visual Studio Professional 2017",
+            "description": "Professionelle Entwicklertools und -dienste für kleine Teams"
+        }
+    ],
+    "launchParams": {
+        "fileName": "Common7\\IDE\\devenv.exe"
+    },
+    "enginePath": "C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\resources\\app\\ServiceHub\\Services\\Microsoft.VisualStudio.Setup.Service",
+    "selectedPackages": [
+        {
+            "id": "Microsoft.VisualStudio.Product.Professional",
+            "version": "15.0.26117.0",
+            "type": "Product",
+            "selectedState": "IndividuallySelected"
+        }
+    ],
+    "packages": [
+        {
+			"id": "Microsoft.VisualStudio.Workload.ManagedDesktop",
+			"version": "15.0.26117.0",
+			"type": "Workload"
+        },
+        {
+			"id": "Microsoft.VisualStudio.Workload.CoreEditor",
+			"version": "15.0.26117.0",
+			"type": "Workload"
+        },
+        {
+			"id": "Microsoft.VisualStudio.Branding.Professional",
+			"version": "15.0.26117.0",
+			"type": "Vsix"
+        },
+        {
+            "id": "Microsoft.VisualStudio.Product.Professional",
+            "version": "15.0.26117.0",
+            "type": "Product"
+        }
+    ]
+}

--- a/test/docker/Instances/4/state.json
+++ b/test/docker/Instances/4/state.json
@@ -1,0 +1,44 @@
+{
+    "installationName": "VisualStudio/public.d15rel/15.0.26117.0",
+    "installationVersion": "15.0.26117.0",
+    "installationPath": "C:\\BuildTools",
+    "installDate": "2017-01-18T03:45:00Z",
+    "product": {
+        "id": "Microsoft.VisualStudio.Product.BuildTools",
+        "version": "15.0.26117.0",
+        "type": "Product"
+    },
+    "localizedResources": [
+        {
+            "language": "en-us",
+            "title": "Visual Studio Build Tools 2017",
+            "description": "The Visual Studio Build Tools allows you to build native and managed MSBuild-based applications without requiring the Visual Studio IDE. There are options to install the Visual C++ compilers and libraries, MFC, ATL, and C++/CLI support."
+        },
+        {
+            "language": "de-de",
+            "title": "Visual Studio-Buildtools 2017",
+            "description": "Die Visual Studio-Buildtools ermöglichen Ihnen die Erstellung nativer und verwalteter MSBuild-basierter Anwendungen, ohne dass die Visual Studio-IDE erforderlich ist. Es stehen Optionen zur Installation von Visual C++-Compilern und -Bibliotheken, MFC, ATL sowie C++/CLI-Unterstützung zur Verfügung."
+        }
+    ],
+    "enginePath": "C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\resources\\app\\ServiceHub\\Services\\Microsoft.VisualStudio.Setup.Service",
+    "selectedPackages": [
+        {
+            "id": "Microsoft.VisualStudio.Product.BuildTools",
+            "version": "15.0.26117.0",
+            "type": "Product",
+            "selectedState": "IndividuallySelected"
+        }
+    ],
+    "packages": [
+        {
+			"id": "Microsoft.VisualStudio.Workload.MSBuildTools",
+			"version": "15.0.26117.0",
+			"type": "Workload"
+        },
+        {
+            "id": "Microsoft.VisualStudio.Product.BuildTools",
+            "version": "15.0.26117.0",
+            "type": "Product"
+        }
+    ]
+}

--- a/test/docker/Tests/GetInstance.Tests.ps1
+++ b/test/docker/Tests/GetInstance.Tests.ps1
@@ -1,0 +1,57 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+
+Describe 'Get-VSSetupInstance' {
+    $en = New-Object System.Globalization.CultureInfo 'en-US'
+    $de = New-Object System.Globalization.CultureInfo 'de-DE'
+
+    Context 'Launchable instances' {
+        [System.Globalization.CultureInfo]::CurrentUICulture = $en
+        $instances = Get-VSSetupInstance
+
+        It 'Returns 3 instances' {
+            $instances.Count | Should Be 3
+        }
+    }
+
+    Context 'All instances' {
+        [System.Globalization.CultureInfo]::CurrentUICulture = $en
+        $instances = Get-VSSetupInstance -All
+
+        It 'Returns 4 instances' {
+            $instances.Count | Should Be 4
+        }
+    }
+
+    Context 'Specified path' {
+        It 'Accepts pipeline input' {
+            [System.Globalization.CultureInfo]::CurrentUICulture = $en
+            $instance = Get-Item C:\VS\Community | Get-VSSetupInstance
+
+            $instance.InstanceId | Should Be 1
+        }
+        It 'Returns Community properties' {
+            [System.Globalization.CultureInfo]::CurrentUICulture = $en
+            $instance = Get-VSSetupInstance 'C:\VS\Community'
+
+            $instance.InstanceId | Should Be 1
+            $instance.InstallationName | Should Be 'VisualStudio/public.d15rel/15.0.26116.0'
+            $instance.InstallationPath | Should Be 'C:\VS\Community'
+            $instance.InstallationVersion | Should Be '15.0.26116.0'
+            $instance.DisplayName | Should Be 'Visual Studio Community 2017'
+            $instance.Description | Should Match '^Free'
+            $instance.Product.Id | Should Be 'Microsoft.VisualStudio.Product.Community'
+            $instance.Product.Version | Should Be '15.0.26116.0'
+            $instance.Packages.Count | Should Be 4
+        }
+
+        It 'Returns Community properties (de-DE)' {
+            [System.Globalization.CultureInfo]::CurrentUICulture = $de
+            $instance = Get-VSSetupInstance 'C:\VS\Community'
+
+            $instance.InstanceId | Should Be 1
+            $instance.DisplayName | Should Be 'Visual Studio Community 2017'
+            $instance.Description | Should Match '^Kostenlose'
+        }
+    }
+}

--- a/test/docker/Tests/SelectInstance.Tests.ps1
+++ b/test/docker/Tests/SelectInstance.Tests.ps1
@@ -1,0 +1,59 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+
+Describe 'Select-VSSetupInstance' {
+    Context 'Defaults to VS' {
+        $instances = Get-VSSetupInstance | Select-VSSetupInstance
+
+        It 'Returns 2 instances' {
+            $instances.Count | Should Be 2
+        }
+    }
+
+    Context 'Returns latest launchable VS' {
+        $instances = Get-VSSetupInstance | Select-VSSetupInstance -Latest
+
+        It 'Returns 1 instance' {
+            $instances.Count | Should Be 1
+        }
+
+        It 'Returns Enterprise instance' {
+            $instances[0].InstanceId | Should Be 2
+            $instances[0].Product.Id | Should Be 'Microsoft.VisualStudio.Product.Enterprise'
+        }
+    }
+
+    Context 'Returns latest VS' {
+        $instances = Get-VSSetupInstance -All | Select-VSSetupInstance -Latest
+
+        It 'Returns 1 instance' {
+            $instances.Count | Should Be 1
+        }
+
+        It 'Returns Professional instance' {
+            $instances[0].InstanceId | Should Be 3
+            $instances[0].Product.Id | Should Be 'Microsoft.VisualStudio.Product.Professional'
+        }
+    }
+
+    Context 'Supports other products' {
+        $instances = Get-VSSetupInstance | Select-VSSetupInstance -Product 'Microsoft.VisualStudio.Product.BuildTools'
+
+        It 'Returns 1 instance' {
+            $instances.Count | Should Be 1
+        }
+
+        It 'Returns Build Tools instance' {
+            $instances[0].InstanceId | Should Be 4
+            $instances[0].Product.Id | Should Be 'Microsoft.VisualStudio.Product.BuildTools'
+        }
+    }
+
+    Context 'Queries specified workloads' {
+        $instances = Get-VSSetupInstance | Select-VSSetupInstance -Require 'Microsoft.VisualStudio.Workload.ManagedDesktop'
+
+        It 'Returns 2 insances' {
+            $instances.Count | Should Be 2
+        }
+    }
+}

--- a/test/docker/build.cmd
+++ b/test/docker/build.cmd
@@ -1,0 +1,63 @@
+@echo off
+
+REM Copyright (C) Microsoft Corporation. All rights reserved.
+REM Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+
+setlocal enabledelayedexpansion
+
+set projectDir=%~dp0
+set solutionDir=%projectDir:~0,-12%
+
+set name=vssetup/test
+
+:parse
+if "%1"=="" goto :parse_end
+if /i "%1"=="-name" set name=%2& shift& shift& goto :parse
+if /i "%1"=="/name" set name=%2& shift& shift& goto :parse
+if /i "%1"=="-network" set network=%2& shift& shift& goto :parse
+if /i "%1"=="/network" set network=%2& shift& shift& goto :parse
+if "%1"=="-?" goto :help
+if "%1"=="/?" goto :help
+if /i "%1"=="-help" goto :help
+if /i "%1"=="/help" goto :help
+
+echo.
+echo Unknown argument: %1
+goto :help
+
+:parse_end
+if "%network%"=="" (
+    for /f "usebackq" %%i in (`docker network ls --filter driver^=transparent --format "{{.Name}}"`) do (
+        echo Discovered transparent network: %%i
+        set network=%%i
+    )
+
+    echo Using network: !network!
+)
+
+if "%network%"=="" (
+    echo Error: No network selected. Cannot retrieve online resources.
+    exit /b 87
+)
+
+REM Remove trailing backslash or command may fail.
+set root=%projectDir:~0,-1%
+
+@echo on
+docker build --network %network% --tag %name% "%root%"
+
+@echo off
+echo.
+goto :EOF
+
+:help
+echo.
+echo %~nx0 [options] [-?]
+echo.
+echo Options:
+echo -name    Image name. Defaults to vssetup/test.
+echo -network External network name. Defaults to discovered transparent network.
+echo -?       Displays this help message.
+echo.
+
+exit /b 87

--- a/test/docker/build.cmd
+++ b/test/docker/build.cmd
@@ -45,6 +45,7 @@ set root=%projectDir:~0,-1%
 
 @echo on
 docker build --network "%network%" --tag %name% "%root%"
+@if errorlevel 1 exit /b %ERRORLEVEL%
 
 @echo off
 echo.

--- a/test/docker/build.cmd
+++ b/test/docker/build.cmd
@@ -27,7 +27,7 @@ goto :help
 
 :parse_end
 if "%network%"=="" (
-    for /f "usebackq" %%i in (`docker network ls --filter driver^=transparent --format "{{.Name}}"`) do (
+    for /f "usebackq tokens=*" %%i in (`docker network ls --filter driver^=transparent --format "{{.Name}}"`) do (
         echo Discovered transparent network: %%i
         set network=%%i
     )
@@ -44,7 +44,7 @@ REM Remove trailing backslash or command may fail.
 set root=%projectDir:~0,-1%
 
 @echo on
-docker build --network %network% --tag %name% "%root%"
+docker build --network "%network%" --tag %name% "%root%"
 
 @echo off
 echo.

--- a/test/docker/run.cmd
+++ b/test/docker/run.cmd
@@ -39,6 +39,7 @@ set outputPath=%solutionDir%src\VSSetup.PowerShell\bin\%configuration%
 
 @echo on
 docker run -it -v "%outputPath%:C:\Users\ContainerAdministrator\Documents\WindowsPowerShell\Modules\VSSetup" %params% %name% %args%
+@if errorlevel 1 exit /b %ERRORLEVEL%
 
 @echo off
 echo.

--- a/test/docker/run.cmd
+++ b/test/docker/run.cmd
@@ -18,8 +18,8 @@ if /i "%1"=="-name" set name=%2& shift& shift& goto :parse
 if /i "%1"=="/name" set name=%2& shift& shift& goto :parse
 if /i "%1"=="-configuration" set configuration=%2& shift& shift& goto :parse
 if /i "%1"=="/configuration" set configuration=%2& shift& shift& goto :parse
-if /i "%1"=="-network" set params=%params% --network %2& shift& shift& goto :parse
-if /i "%1"=="/network" set params=%params% --network %2& shift& shift& goto :parse
+if /i "%1"=="-network" set params=%params% --network "%2"& shift& shift& goto :parse
+if /i "%1"=="/network" set params=%params% --network "%2"& shift& shift& goto :parse
 if /i "%1"=="-keep" set keep=1& shift& goto :parse
 if /i "%1"=="/keep" set keep=1& shift& goto :parse
 if "%1"=="-?" goto :help

--- a/test/docker/run.cmd
+++ b/test/docker/run.cmd
@@ -1,0 +1,62 @@
+@echo off
+
+REM Copyright (C) Microsoft Corporation. All rights reserved.
+REM Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+
+setlocal
+
+set projectDir=%~dp0
+set solutionDir=%projectDir:~0,-12%
+
+set configuration=Debug
+set name=vssetup/test
+
+:parse
+if "%1"=="" goto :parse_end
+if not "%args%"=="" set args=%args% %1& shift& goto :parse
+if /i "%1"=="-name" set name=%2& shift& shift& goto :parse
+if /i "%1"=="/name" set name=%2& shift& shift& goto :parse
+if /i "%1"=="-configuration" set configuration=%2& shift& shift& goto :parse
+if /i "%1"=="/configuration" set configuration=%2& shift& shift& goto :parse
+if /i "%1"=="-network" set params=%params% --network %2& shift& shift& goto :parse
+if /i "%1"=="/network" set params=%params% --network %2& shift& shift& goto :parse
+if /i "%1"=="-keep" set keep=1& shift& goto :parse
+if /i "%1"=="/keep" set keep=1& shift& goto :parse
+if "%1"=="-?" goto :help
+if "%1"=="/?" goto :help
+if /i "%1"=="-help" goto :help
+if /i "%1"=="/help" goto :help
+if "%1"=="--" set args=%2& shift& shift& goto :parse
+
+echo.
+echo Unknown argument: %1
+goto :help
+
+:parse_end
+if "%keep%"=="" set params=%params% --rm
+
+set outputPath=%solutionDir%src\VSSetup.PowerShell\bin\%configuration%
+
+@echo on
+docker run -it -v "%outputPath%:C:\Users\ContainerAdministrator\Documents\WindowsPowerShell\Modules\VSSetup" %params% %name% %args%
+
+@echo off
+echo.
+goto :EOF
+
+:help
+echo.
+echo %~nx0 [options] [-?] [-- <args>]
+echo.
+echo Options:
+echo -name          Image name. Defaults to vssetup/test.
+echo -configuration The build configuration to map. Defaults to Debug.
+echo -network       External network name. Defaults to discovered transparent network.
+echo -keep          Do not delete the container after exiting.
+echo -?             Displays this help message.
+echo.
+echo Arguments:
+echo --             Any arguments after -- are passed to the container entry point.
+echo.
+
+exit /b 87

--- a/test/docker/test.cmd
+++ b/test/docker/test.cmd
@@ -1,0 +1,8 @@
+@echo off
+
+REM Copyright (C) Microsoft Corporation. All rights reserved.
+REM Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+
+setlocal
+
+%~dp0run.cmd %* -- -c Invoke-Pester C:\Tests -EnableExit


### PR DESCRIPTION
Create Docker image containing Pester tests and the built module for runtime testing. For now this needs to be run manually until integration tests using Docker can be hooked up.