### PR TITLE
Remove unnecessary discovery of test adapter

### DIFF
--- a/tools/test.ps1
+++ b/tools/test.ps1
@@ -67,15 +67,6 @@ if ($Type -contains 'Unit')
         "$path"
     }
 
-    # Find the test adapter.
-    $adapter = get-childitem "$PSScriptRoot\..\packages\xunit.runner.visualstudio*" -filter xunit.runner.visualstudio.testadapter.dll -recurse | select-object -first 1 -expand FullName | foreach-object {
-        "/TestAdapterPath:`"$($_.FullName)`""
-    }
-
-    if (-not $adapter) {
-        write-warning 'Could not find test adapter. Unit tests may not be discovered.'
-    }
-
     # Run unit tests.
     & $cmd $logger $assemblies /parallel /platform:$Platform
     if (-not $?) {


### PR DESCRIPTION
This wasn't hooked up before and isn't straight forward to select the right one across any version of xunit.runner.visualstudio, so just remove discovery since it is working both locally and on AppVeyor.