### PR TITLE
Add $VSSetupVersionTable and drop NuProj

### DIFF
--- a/VSSetup.PowerShell.sln
+++ b/VSSetup.PowerShell.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.7
+VisualStudioVersion = 15.0.26919.1
 MinimumVisualStudioVersion = 15.0.26228.4
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{FEED13D9-C881-407F-A945-7555704789C0}"
 EndProject
@@ -39,5 +39,8 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{F77937D9-8B7C-46AC-80D3-DFDE39EB3279} = {FEED13D9-C881-407F-A945-7555704789C0}
 		{ED12C009-A3E6-4F22-999A-FCA8C84DB41A} = {73C57796-F1DD-49D8-9A5D-9F58764C0078}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {CBFF0D31-054E-4C81-97CC-0F5790C8CCD8}
 	EndGlobalSection
 EndGlobal

--- a/docker/Tests/VersionTable.Tests.ps1
+++ b/docker/Tests/VersionTable.Tests.ps1
@@ -1,0 +1,16 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+
+Describe 'VSSetupVersionTable' {
+    Context 'ModuleVersion' {
+        It 'Is Version' {
+            $VSSetupVersionTable.ModuleVersion -is [System.Version] | Should Be $true
+        }
+    }
+
+    Context 'QueryVersion' {
+        It 'Is Version' {
+            $VSSetupVersionTable.QueryVersion -is [System.Version] | Should Be $true
+        }
+    }
+}

--- a/docs/VSSetup/about_VSSetup.md
+++ b/docs/VSSetup/about_VSSetup.md
@@ -7,6 +7,18 @@ Enumerate and select instances of Visual Studio.
 # LONG DESCRIPTION
 Visual Studio 2017 introduced a new setup engine capable of installing multiple instances of Visual Studio and other products in the Visual Studio family. This module provides commands to enumerate those instances and select instances that meet your criteria. For example, in a development environment you might have a script that finds an instance of Visual Studio with the the Managed Desktop workload for writing projects targeting the .NET Framework. See below for more examples.
 
+# VARIABLES
+You can get the version of this module or of the query API the module uses from the `$VSSetupVersionTable` variable.
+
+```
+PS> $VSSetupVersionTable
+
+Name                           Value
+----                           -----
+QueryVersion                   1.15.23.19330
+ModuleVersion                  2.1.2.4917
+```
+
 # EXAMPLES
 You can enumerate all instances - even those with errors that require a repair - with the following command.
 

--- a/src/VSSetup.PowerShell/Extensions.cs
+++ b/src/VSSetup.PowerShell/Extensions.cs
@@ -6,6 +6,10 @@
 namespace Microsoft.VisualStudio.Setup
 {
     using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
     using System.Text;
 
     /// <summary>
@@ -13,6 +17,36 @@ namespace Microsoft.VisualStudio.Setup
     /// </summary>
     internal static class Extensions
     {
+        /// <summary>
+        /// Gets a custom attribute of type <typeparamref name="T"/> defined on the assembly.
+        /// </summary>
+        /// <typeparam name="T">The type of attribute to get.</typeparam>
+        /// <param name="source">The <see cref="Assembly"/> on which the custom attribute may be defined.</param>
+        /// <returns>A custom attribute of type <typeparamref name="T"/> defined on the assembly.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
+        public static T GetCustomAttribute<T>(this Assembly source)
+            where T : Attribute
+        {
+            Validate.NotNull(source, nameof(source));
+
+            return source.GetCustomAttributes<T>()?.FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Gets a collection of custom attributes of type <typeparamref name="T"/> defined on the assembly.
+        /// </summary>
+        /// <typeparam name="T">The type of attributes to get.</typeparam>
+        /// <param name="source">The <see cref="Assembly"/> on which the custom attributes may be defined.</param>
+        /// <returns>A collection of custom attributes of type <typeparamref name="T"/> defined on the assembly.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
+        public static IEnumerable<T> GetCustomAttributes<T>(this Assembly source)
+            where T : Attribute
+        {
+            Validate.NotNull(source, nameof(source));
+
+            return source.GetCustomAttributes(typeof(T), false)?.OfType<T>();
+        }
+
         /// <summary>
         /// Returns a <see cref="Version"/> without negative fields.
         /// </summary>

--- a/src/VSSetup.PowerShell/Lazy.cs
+++ b/src/VSSetup.PowerShell/Lazy.cs
@@ -13,6 +13,7 @@ namespace Microsoft.VisualStudio.Setup
     /// <typeparam name="T">The type to create when <see cref="Value"/> is first accessed.</typeparam>
     internal class Lazy<T> : IDisposable
     {
+        private readonly object syncRoot = new object();
         private readonly Func<T> factory;
         private bool hasValue = false;
         private T value = default(T);
@@ -34,7 +35,7 @@ namespace Microsoft.VisualStudio.Setup
         {
             get
             {
-                lock (this)
+                lock (syncRoot)
                 {
                     return hasValue;
                 }
@@ -50,7 +51,7 @@ namespace Microsoft.VisualStudio.Setup
             {
                 if (!hasValue)
                 {
-                    lock (this)
+                    lock (syncRoot)
                     {
                         if (!hasValue)
                         {

--- a/src/VSSetup.PowerShell/Lazy.cs
+++ b/src/VSSetup.PowerShell/Lazy.cs
@@ -1,0 +1,76 @@
+﻿// <copyright file="Lazy.cs" company="Microsoft Corporation">
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+// </copyright>
+
+namespace Microsoft.VisualStudio.Setup
+{
+    using System;
+
+    /// <summary>
+    /// Creates an instance of <typeparamref name="T"/> only when <see cref="Value"/> is first accessed.
+    /// </summary>
+    /// <typeparam name="T">The type to create when <see cref="Value"/> is first accessed.</typeparam>
+    internal class Lazy<T> : IDisposable
+    {
+        private readonly Func<T> factory;
+        private bool hasValue = false;
+        private T value = default(T);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Lazy{T}"/> class.
+        /// </summary>
+        /// <param name="factory">A <see cref="Func{TResult}"/> to create an instance of the type.</param>
+        public Lazy(Func<T> factory)
+        {
+            Validate.NotNull(factory, nameof(factory));
+            this.factory = factory;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="Value"/> has been created.
+        /// </summary>
+        public bool HasValue
+        {
+            get
+            {
+                lock (this)
+                {
+                    return hasValue;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets an instance of the type.
+        /// </summary>
+        public T Value
+        {
+            get
+            {
+                if (!hasValue)
+                {
+                    lock (this)
+                    {
+                        if (!hasValue)
+                        {
+                            value = factory();
+                            hasValue = true;
+                        }
+                    }
+                }
+
+                return value;
+            }
+        }
+
+        /// <inheritdoc/>
+        void IDisposable.Dispose()
+        {
+            if (value is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
+    }
+}

--- a/src/VSSetup.PowerShell/Module.cs
+++ b/src/VSSetup.PowerShell/Module.cs
@@ -1,0 +1,134 @@
+﻿// <copyright file="Module.cs" company="Microsoft Corporation">
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+// </copyright>
+
+namespace Microsoft.VisualStudio.Setup
+{
+    using System;
+    using System.Diagnostics;
+    using System.Runtime.InteropServices;
+    using System.Text;
+
+    /// <summary>
+    /// A native module.
+    /// </summary>
+    internal class Module : IDisposable
+    {
+        private readonly SafeModuleHandle handle;
+        private string path = null;
+
+        private Module(SafeModuleHandle handle)
+        {
+            this.handle = handle;
+        }
+
+        ~Module()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the object is already disposed.
+        /// </summary>
+        public bool IsDisposed { get; private set; }
+
+        /// <summary>
+        /// Gets the path to the <see cref="Module"/>.
+        /// </summary>
+        public string Path
+        {
+            get
+            {
+                if (path == null)
+                {
+                    var sb = new StringBuilder(NativeMethods.MAX_PATH);
+                    var length = NativeMethods.GetModuleFileName(handle, sb, sb.Capacity);
+
+                    if (length > 0)
+                    {
+                        path = sb.ToString();
+                    }
+                }
+
+                return path;
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Version"/> of the module.
+        /// </summary>
+        public Version Version
+        {
+            get
+            {
+                var path = Path;
+
+                if (!string.IsNullOrEmpty(path))
+                {
+                    var info = FileVersionInfo.GetVersionInfo(path);
+                    return new Version(info.FileMajorPart, info.FileMinorPart, info.FileBuildPart, info.FilePrivatePart);
+                }
+
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Gets a <see cref="Module"/> for a runtime-callable wrapper.
+        /// </summary>
+        /// <param name="object">An <see cref="object"/> that represents the COM object.</param>
+        /// <param name="module">The <see cref="Module"/> if the <paramref name="object"/> is a COM object.</param>
+        /// <returns>True if we could get the <see cref="Module"/> for a runtime-callable wrapper for the given COM object; otherwise, false.</returns>
+        public static bool TryFromComObject(object @object, out Module module)
+        {
+            if (@object != null)
+            {
+                var unk = Marshal.GetIUnknownForObject(@object);
+                if (unk != IntPtr.Zero)
+                {
+                    try
+                    {
+                        var addr = Marshal.ReadIntPtr(unk);
+                        if (NativeMethods.GetModuleHandleEx(GetModuleHandleExFlags.FromAddress, addr, out var handle))
+                        {
+                            module = new Module(handle);
+                            return true;
+                        }
+                    }
+                    finally
+                    {
+                        Marshal.Release(unk);
+                    }
+                }
+            }
+
+            module = null;
+            return false;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes the object.
+        /// </summary>
+        /// <param name="disposing">True if the object is being disposed; otherwise, false if the object is being finalized.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!IsDisposed)
+            {
+                if (!handle.IsInvalid)
+                {
+                    handle.Dispose();
+                }
+
+                IsDisposed = true;
+            }
+        }
+    }
+}

--- a/src/VSSetup.PowerShell/NativeMethods.cs
+++ b/src/VSSetup.PowerShell/NativeMethods.cs
@@ -5,6 +5,10 @@
 
 namespace Microsoft.VisualStudio.Setup
 {
+    using System;
+    using System.Runtime.InteropServices;
+    using System.Text;
+
     /// <summary>
     /// Native methods and constants.
     /// </summary>
@@ -16,8 +20,67 @@ namespace Microsoft.VisualStudio.Setup
         public const int E_NOTFOUND = unchecked((int)0x80070490);
 
         /// <summary>
+        /// The maximum path length (legacy).
+        /// </summary>
+        public const int MAX_PATH = 260;
+
+        /// <summary>
         /// Class not registered.
         /// </summary>
         public const int REGDB_E_CLASSNOTREG = unchecked((int)0x80040154);
+
+        /// <summary>
+        /// Gets the file name of the module for the given handle.
+        /// </summary>
+        /// <param name="hModule">The handle of the module.</param>
+        /// <param name="lpFilename">The file name of the module.</param>
+        /// <param name="nSize">The size of the <paramref name="lpFilename"/> buffer.</param>
+        /// <returns>The length of the string in <paramref name="lpFilename"/>; otherwise, 0 if the function fails and <see cref="Marshal.GetLastWin32Error"/> will contain the reason.</returns>
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, EntryPoint = "GetModuleFileNameW", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.U4)]
+        public static extern int GetModuleFileName(
+            SafeModuleHandle hModule,
+            [Out] StringBuilder lpFilename,
+            [MarshalAs(UnmanagedType.U4)] int nSize);
+
+        /// <summary>
+        /// Gets a handle to the module given the module name.
+        /// </summary>
+        /// <param name="dwFlags">The <see cref="GetModuleHandleExFlags"/> for the call.</param>
+        /// <param name="lpModuleName">The name of the module or pointer to a function within the module.</param>
+        /// <param name="phModule">A handle to the module.</param>
+        /// <returns>True if the function succeeds; otherwise, false and <see cref="Marshal.GetLastWin32Error"/> will contain the reason.</returns>
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, EntryPoint = "GetModuleHandleExW", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool GetModuleHandleEx(
+            [MarshalAs(UnmanagedType.U4)] GetModuleHandleExFlags dwFlags,
+            IntPtr lpModuleName,
+            out SafeModuleHandle phModule);
+
+        /// <summary>
+        /// Frees the module given its handle.
+        /// </summary>
+        /// <param name="hModule">The handle to the module to free.</param>
+        /// <returns>True if the function succeeds; otherwise, false and <see cref="Marshal.GetLastWin32Error"/> will contain the reason.</returns>
+        [DllImport("kernel32.dll", ExactSpelling = true, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool FreeLibrary(
+            IntPtr hModule);
     }
+
+#pragma warning disable SA1201 // Elements must appear in the correct order
+
+    /// <summary>
+    /// Flags for <see cref="GetModuleHandleEx(GetModuleHandleExFlags, IntPtr, out SafeHandle)"/>.
+    /// </summary>
+    [Flags]
+    public enum GetModuleHandleExFlags
+    {
+        /// <summary>
+        /// The module name is a pointer to a function within the module.
+        /// </summary>
+        FromAddress = 4,
+    }
+
+#pragma warning restore SA1201 // Elements must appear in the correct order
 }

--- a/src/VSSetup.PowerShell/PowerShell/VersionTable.cs
+++ b/src/VSSetup.PowerShell/PowerShell/VersionTable.cs
@@ -1,0 +1,59 @@
+﻿// <copyright file="VersionTable.cs" company="Microsoft Corporation">
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+// </copyright>
+
+namespace Microsoft.VisualStudio.Setup.PowerShell
+{
+    using System;
+    using System.Collections;
+    using System.Management.Automation;
+    using System.Reflection;
+
+    /// <summary>
+    /// Dynamic property containing version information about this module.
+    /// </summary>
+    public sealed class VersionTable : PSVariable
+    {
+        private readonly Lazy<Hashtable> properties;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VersionTable"/> class.
+        /// </summary>
+        public VersionTable()
+            : base("VSSetupVersionTable", null, ScopedItemOptions.Constant)
+        {
+            properties = new Lazy<Hashtable>(() =>
+            {
+                var thisVersionAttr = GetType().Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>();
+                Utilities.TryParseVersion(thisVersionAttr?.Version, out var thisVersion);
+
+                return new Hashtable
+                {
+                    ["ModuleVersion"] = thisVersion,
+                    ["QueryVersion"] = TryGetQueryVersion(),
+                };
+            });
+        }
+
+        /// <inheritdoc/>
+        public override object Value => properties.Value;
+
+        private static Version TryGetQueryVersion()
+        {
+            try
+            {
+                var query = QueryFactory.Create();
+                if (Setup.Module.TryFromComObject(query, out var module))
+                {
+                    return module.Version;
+                }
+            }
+            catch
+            {
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/VSSetup.PowerShell/SafeModuleHandle.cs
+++ b/src/VSSetup.PowerShell/SafeModuleHandle.cs
@@ -1,0 +1,35 @@
+﻿// <copyright file="SafeModuleHandle.cs" company="Microsoft Corporation">
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+// </copyright>
+
+namespace Microsoft.VisualStudio.Setup
+{
+    using System;
+    using System.Runtime.InteropServices;
+
+    /// <summary>
+    /// A handle to a module.
+    /// </summary>
+    internal sealed class SafeModuleHandle : SafeHandle
+    {
+        private static readonly IntPtr InvalidHandleValue = IntPtr.Zero;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SafeModuleHandle"/> class.
+        /// </summary>
+        public SafeModuleHandle()
+            : base(InvalidHandleValue, true)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override bool IsInvalid => handle != InvalidHandleValue;
+
+        /// <inheritdoc/>
+        protected override bool ReleaseHandle()
+        {
+            return NativeMethods.FreeLibrary(handle);
+        }
+    }
+}

--- a/src/VSSetup.PowerShell/VSSetup.PowerShell.csproj
+++ b/src/VSSetup.PowerShell/VSSetup.PowerShell.csproj
@@ -51,9 +51,12 @@
     <Compile Include="Extensions.cs" />
     <Compile Include="FailedPackageReference.cs" />
     <Compile Include="Instance.cs" />
+    <Compile Include="Module.cs" />
     <Compile Include="NativeMethods.cs" />
     <Compile Include="PackageReference.cs" />
     <Compile Include="PackageReferenceFactory.cs" />
+    <Compile Include="Lazy.cs" />
+    <Compile Include="PowerShell\VersionTable.cs" />
     <Compile Include="QueryFactory.cs" />
     <Compile Include="PowerShell\Extensions.cs" />
     <Compile Include="PowerShell\GetInstanceCommand.cs" />
@@ -67,6 +70,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
     <Compile Include="ReadOnlyDictionary.cs" />
+    <Compile Include="SafeModuleHandle.cs" />
     <Compile Include="Utilities.cs" />
     <Compile Include="Validate.cs" />
   </ItemGroup>
@@ -75,6 +79,9 @@
       <SubType>Designer</SubType>
     </None>
     <Content Include="VSSetup.types.ps1xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="VSSetup.psm1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Template Include="VSSetup.psd1" />

--- a/src/VSSetup.PowerShell/VSSetup.psd1
+++ b/src/VSSetup.PowerShell/VSSetup.psd1
@@ -9,8 +9,12 @@ Description = 'Visual Studio Setup PowerShell Module'
 ModuleVersion = '$BuildVersion$'
 PowerShellVersion = '2.0'
 CLRVersion = '2.0'
-ModuleToProcess = 'Microsoft.VisualStudio.Setup.PowerShell.dll'
-RequiredAssemblies = 'Microsoft.VisualStudio.Setup.PowerShell.dll'
+ModuleToProcess = 'VSSetup.psm1'
+NestedModules = 'Microsoft.VisualStudio.Setup.PowerShell.dll'
+RequiredAssemblies = @(
+  'Microsoft.VisualStudio.Setup.PowerShell.dll',
+  'Microsoft.VisualStudio.Setup.Configuration.Interop.dll'
+)
 TypesToProcess = 'VSSetup.types.ps1xml'
 PrivateData = @{
   PSData = @{

--- a/src/VSSetup.PowerShell/VSSetup.psm1
+++ b/src/VSSetup.PowerShell/VSSetup.psm1
@@ -1,0 +1,8 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+
+$ExecutionContext.SessionState.PSVariable.Set(
+    (New-Object 'Microsoft.VisualStudio.Setup.PowerShell.VersionTable')
+)
+
+Export-ModuleMember -Cmdlet * -Variable VSSetupVersionTable

--- a/test/VSSetup.PowerShell.Test/ExtensionsTests.cs
+++ b/test/VSSetup.PowerShell.Test/ExtensionsTests.cs
@@ -6,10 +6,38 @@
 namespace Microsoft.VisualStudio.Setup
 {
     using System;
+    using System.Reflection;
     using Xunit;
 
     public class ExtensionsTests
     {
+        [Fact]
+        public void GetCustomAttributeT_Null_Throws()
+        {
+            Assert.Throws<ArgumentNullException>("source", () => Extensions.GetCustomAttribute<Attribute>(null));
+        }
+
+        [Fact]
+        public void GetCustomAttributeT()
+        {
+            var expected = GetType().Assembly.GetCustomAttribute<AssemblyCompanyAttribute>()?.Company;
+            Assert.Equal("Microsoft Corporation", expected);
+        }
+
+        [Fact]
+        public void GetCustomAttributesT_Null_Throws()
+        {
+            Assert.Throws<ArgumentNullException>("source", () => Extensions.GetCustomAttributes<Attribute>(null));
+        }
+
+        [Fact]
+        public void GetCustomAttributesT()
+        {
+            var attributes = GetType().Assembly.GetCustomAttributes<AssemblyCompanyAttribute>();
+            Assert.Collection(attributes, attr => Assert.Equal("Microsoft Corporation", attr.Company));
+        }
+
+        [Fact]
         public void Normalize_Null_Throws()
         {
             Assert.Throws<ArgumentNullException>("version", () => Extensions.Normalize(null));

--- a/test/VSSetup.PowerShell.Test/LazyTests.cs
+++ b/test/VSSetup.PowerShell.Test/LazyTests.cs
@@ -1,0 +1,55 @@
+﻿// <copyright file="LazyTests.cs" company="Microsoft Corporation">
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+// </copyright>
+
+namespace Microsoft.VisualStudio.Setup
+{
+    using System;
+    using Moq;
+    using Xunit;
+
+    public class LazyTests
+    {
+        [Fact]
+        public void New_Factory_Null_Throws()
+        {
+            Assert.Throws<ArgumentNullException>("factory", () => new Lazy<string>(null));
+        }
+
+        [Fact]
+        public void Value_Initializes()
+        {
+            var sut = new Lazy<string>(() => new string(new[] { 't', 'e', 's', 't' }));
+            Assert.False(sut.HasValue);
+
+            Assert.Equal("test", sut.Value);
+            Assert.True(sut.HasValue);
+        }
+
+        [Fact]
+        public void Disposes()
+        {
+            var disposable = new Mock<IDisposable>();
+            using (var sut = new Lazy<IDisposable>(() => disposable.Object))
+            {
+                Assert.NotNull(sut.Value);
+                Assert.True(sut.HasValue);
+            }
+
+            disposable.Verify(x => x.Dispose(), Times.Once);
+        }
+
+        [Fact]
+        public void No_Initialize_No_Dispose()
+        {
+            var disposable = new Mock<IDisposable>();
+            using (var sut = new Lazy<IDisposable>(() => disposable.Object))
+            {
+                Assert.False(sut.HasValue);
+            }
+
+            disposable.Verify(x => x.Dispose(), Times.Never);
+        }
+    }
+}

--- a/test/VSSetup.PowerShell.Test/ModuleTests.cs
+++ b/test/VSSetup.PowerShell.Test/ModuleTests.cs
@@ -1,0 +1,40 @@
+﻿// <copyright file="ModuleTests.cs" company="Microsoft Corporation">
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+// </copyright>
+
+namespace Microsoft.VisualStudio.Setup
+{
+    using Microsoft.VisualStudio.Setup.Configuration;
+    using Xunit;
+
+    public class ModuleTests
+    {
+        [Fact]
+        public void TryFromComObject_Null()
+        {
+            Assert.False(Module.TryFromComObject(null, out var module));
+            Assert.Null(module);
+        }
+
+        [Fact]
+        public void TryFromComObject_Not_Com()
+        {
+            Assert.False(Module.TryFromComObject(string.Empty, out var module));
+            Assert.Null(module);
+        }
+
+        [Fact]
+        public void TryFromComObject()
+        {
+            var query = new SetupConfiguration();
+
+            var result = Module.TryFromComObject(query, out var module);
+            using (module)
+            {
+                Assert.True(result);
+                Assert.NotNull(module);
+            }
+        }
+    }
+}

--- a/test/VSSetup.PowerShell.Test/VSSetup.PowerShell.Test.csproj
+++ b/test/VSSetup.PowerShell.Test/VSSetup.PowerShell.Test.csproj
@@ -82,6 +82,8 @@
     <Compile Include="ExtensionsTests.cs" />
     <Compile Include="FailedPackageReferenceTests.cs" />
     <Compile Include="InstanceTests.cs" />
+    <Compile Include="LazyTests.cs" />
+    <Compile Include="ModuleTests.cs" />
     <Compile Include="PackageReferenceFactoryTests.cs" />
     <Compile Include="PackageReferenceTests.cs" />
     <Compile Include="PowerShell\ExtensionsTests.cs" />

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/tags/v\\d\\.\\d"


### PR DESCRIPTION
Added new variable `$VSSetupVersionTable` (akin to showing the query API version - if installed - in vswhere) and dropped support for NuProj since it doesn't (and most likely won't) support VS2017. Instead, AppVeyor will build it from the command line for PR and CI builds.