### PR TITLE
Remove date comparison from SelectInstanceCommand

### DIFF
--- a/src/VSSetup.PowerShell/PowerShell/SelectInstanceCommand.cs
+++ b/src/VSSetup.PowerShell/PowerShell/SelectInstanceCommand.cs
@@ -149,10 +149,7 @@ namespace Microsoft.VisualStudio.Setup.PowerShell
             {
                 if (Latest)
                 {
-                    if (latestInstance == null || latestInstance.InstallDate < instance.InstallDate)
-                    {
-                        latestInstance = instance;
-                    }
+                   latestInstance = instance;
                 }
                 else
                 {


### PR DESCRIPTION
The **InstanceComparer** that was added as part of #41 to fix #40 isn't actually able to solve the problem due to the implementation of the **ProcessRecord** method in **SelectInstanceCommand**. **InstanceComparer** is used to sort instances by version and then date, but when iterating over all instances, the **latestInstance** variable is only set when the **latestInstance** date is less than the date of the current instance in the loop.

This completely ignores the previous **OrderBy** that was done using **InstanceComparer**. The simplest solution at this point is to always set the **latestInstance** variable when the Latest flag is set because the collection is already sorted in the desired order and no additional comparisons are necessary.