### PR TITLE
Add compliance build

### DIFF
--- a/.vsts-compliance.yml
+++ b/.vsts-compliance.yml
@@ -1,0 +1,79 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+
+trigger:
+  batch: true
+  branches:
+    include:
+    - master
+    - develop
+  paths:
+    exclude:
+    - README.md
+
+pr: none
+
+queue:
+  name: VSEngSS-MicroBuild2019-1ES
+  timeoutInMinutes: 120
+  demands:
+  - MSBuild
+  - VisualStudio
+  - VSTest
+
+steps:
+- template: build/build.yml
+  parameters:
+      BuildConfiguration: $(BuildConfiguration)
+      BuildPlatform: $(BuildPlatform)
+      Sign: false
+
+- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+  displayName: Detect components
+  inputs:
+    sourceScanPath: $(Build.SourcesDirectory)
+
+- task: RoslynAnalyzers@3
+  inputs:
+    userProvideBuildInfo: 'autoMsBuildInfo'
+  env:
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
+  displayName: 'Run PoliCheck'
+  inputs:
+    targetType: F
+    targetArgument: '$(Build.SourcesDirectory)'
+    optionsFC: 0
+    optionsXS: 1
+    optionsHMENABLE: 0
+  continueOnError: true
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
+  displayName: 'Run BinSkim'
+  inputs:
+    InputType: Basic
+    Function: analyze
+    AnalyzeTarget: '$(Build.SourcesDirectory)\src\VSSetup.PowerShell\bin\$(BuildConfiguration)\*.dll'
+    AnalyzeSymPath: '$(Build.SourcesDirectory)\src\VSSetup.PowerShell\bin\$(BuildConfiguration)'
+    AnalyzeVerbose: true
+    AnalyzeHashes: true
+  continueOnError: true
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
+  displayName: 'Run CredScan'
+  inputs:
+    debugMode: false
+
+# Publish compliance results
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
+  displayName: 'Publish Security Analysis Logs'
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
+  displayName: Check SDL results
+  inputs:
+    AllTools: true
+
+- task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
+  displayName: Clean up
+  condition: succeededOrFailed()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@
 # Licensed under the MIT license. See LICENSE.txt in the project root for license information.
 
 # Based on latest image cached by Azure Pipelines: https://docs.microsoft.com/azure/devops/pipelines/agents/hosted#software
-FROM microsoft/windowsservercore@sha256:ac71e33f27c2a6b5db30be0419458e0c4e926214bc9c85afd4d6d6f9028d7233
+FROM microsoft/windowsservercore@sha256:22cc6661c975edc09fa44c497f8310b264da4ff102a56a974e4cf1a790626a22
 SHELL ["powershell.exe", "-ExecutionPolicy", "Bypass", "-Command"]
 
 ENV INSTALLER_VERSION=1.14.190.31519 `


### PR DESCRIPTION
To be compliant with Microsoft policies we need to run a compliance build on a regular schedule. 

This will add a CI build pipeline that will execute all of our required compliance runs.