### PR TITLE
Update compliance build to run API scan and log bugs

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,8 @@
+{
+    "codebaseName": "Microsoft.VSSetup.PowerShell",
+    "instanceUrl": "https://devdiv.visualstudio.com/defaultcollection",
+    "projectName": "DevDiv",
+    "areaPath": "DevDiv\\VS Setup",
+    "iterationPath": "DevDiv",
+    "allTools": true
+  }

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -13,8 +13,6 @@ trigger:
 
 pr: none
 
-pool: VSEngSS-MicroBuild2022-1ES
-
 resources:
   repositories:
     - repository: MicroBuildTemplate
@@ -28,11 +26,18 @@ extends:
     pool:
       name: VSEngSS-MicroBuild2022-1ES
     sdl:
+      sourceAnalysisPool:
+        name: AzurePipelines-EO
+        image: 1ESPT-Windows2022
       policheck:
         enabled: true
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true
+      tsa:
+        enabled: true
+        configFile: $(Build.SourcesDirectory)\.config\tsaoptions.json
+        onboard: false # We already onboarded
 
     stages:
       - stage: Build
@@ -51,7 +56,3 @@ extends:
                     BuildPlatform: $(BuildPlatform)
                     Sign: true
                     PublishArtifactTemplate: /build/templates/1es-publish-task.yml@self
-
-              - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
-                displayName: Clean up
-                condition: succeededOrFailed()

--- a/.vsts-compliance.yml
+++ b/.vsts-compliance.yml
@@ -1,6 +1,14 @@
 # Copyright (C) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT license. See LICENSE.txt in the project root for license information.
 
+variables:
+- group: vssetup-apiscan
+- group: vssetup-apiscan-secrets
+- name: BuildConfiguration
+  value: Release
+- name: TeamName
+  value: vssetup
+
 trigger:
   batch: true
   branches:
@@ -11,77 +19,106 @@ trigger:
     exclude:
     - README.md
 
+pr: none
+
 schedules:
-- cron: "0 18 * * Mon"
-  displayName: Monday 11am PDT (6pm UTC) build
+- cron: "0 12 * * 1"
+  displayName: 'Run every Monday at 12:00 p.m.'
   branches:
     include:
     - master
+    - develop
   always: true
 
-pr: none
+resources:
+  repositories:
+    - repository: MicroBuildTemplate
+      type: git
+      name: 1ESPipelineTemplates/MicroBuildTemplate
+      ref: refs/tags/release
 
-queue:
-  name: VSEngSS-MicroBuild2019-1ES
-  timeoutInMinutes: 120
-  demands:
-  - MSBuild
-  - VisualStudio
-  - VSTest
-
-steps:
-- template: build/build.yml
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
   parameters:
-      BuildConfiguration: $(BuildConfiguration)
-      BuildPlatform: $(BuildPlatform)
-      Sign: false
+    pool:
+      name: VSEngSS-MicroBuild2022-1ES
+    sdl:
+      sourceAnalysisPool:
+        name: AzurePipelines-EO
+        image: 1ESPT-Windows2022
+      antimalwareScan:
+        enabled: true
+      armory:
+        enabled: true
+      binskim:
+        enabled: true
+        scanOutputDirectoryOnly: true
+      codeql:
+        compiled:
+          enabled: true
+      credscan:
+        enabled: true
+      policheck:
+        enabled: true
+      psscriptanalyzer:
+        enabled: true
+      prefast:
+        enabled: true
+      tsa:
+        enabled: true
+        configFile: $(Build.SourcesDirectory)\.config\tsaoptions.json
+        onboard: false # We already onboarded
 
-- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-  displayName: Detect components
-  inputs:
-    sourceScanPath: $(Build.SourcesDirectory)
+    stages:
+      - stage: Compliance
+        jobs:
+          - job: Compliance
+            steps:
+              - template: /build/build.yml@self
+                parameters:
+                  BuildConfiguration: $(BuildConfiguration)
+                  BuildPlatform: $(BuildPlatform)
+                  Sign: false
 
-- task: RoslynAnalyzers@3
-  inputs:
-    userProvideBuildInfo: 'autoMsBuildInfo'
-  env:
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+              - task: CopyFiles@2
+                displayName: Copy files for API scan
+                inputs:
+                  SourceFolder: $(Build.SourcesDirectory)\src\VSSetup.PowerShell\bin\$(BuildConfiguration)
+                  Contents: |
+                    **\*.?(pdb|exe|dll|xml)
+                    !**\*.Test.*
+                  TargetFolder: $(Build.StagingDirectory)\apiscan-inputs
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
-  displayName: 'Run PoliCheck'
-  inputs:
-    targetType: F
-    targetArgument: '$(Build.SourcesDirectory)'
-    optionsFC: 0
-    optionsXS: 1
-    optionsHMENABLE: 0
-  continueOnError: true
+              - task: APIScan@2
+                displayName: Run APIScan
+                inputs:
+                  softwareFolder: $(Build.StagingDirectory)\apiscan-inputs
+                  softwareName: 'Microsoft.VSConfigFinder'
+                  softwareVersionNum: '1'
+                  toolVersion: Latest
+                env:
+                  AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(SetupAppApiScanSecret)
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
-  displayName: 'Run BinSkim'
-  inputs:
-    InputType: Basic
-    Function: analyze
-    AnalyzeTarget: '$(Build.SourcesDirectory)\src\VSSetup.PowerShell\bin\$(BuildConfiguration)\*.dll'
-    AnalyzeSymPath: '$(Build.SourcesDirectory)\src\VSSetup.PowerShell\bin\$(BuildConfiguration)'
-    AnalyzeVerbose: true
-    AnalyzeHashes: true
-  continueOnError: true
+              - task: PublishSecurityAnalysisLogs@3
+                displayName: Publish 'SDLAnalysis-APIScan' artifact
+                condition: succeededOrFailed()
+                inputs:
+                  ArtifactName: SDLAnalysis-APIScan
+                  AllTools: false
+                  APIScan: true
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
-  displayName: 'Run CredScan'
-  inputs:
-    debugMode: false
-
-# Publish compliance results
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
-  displayName: 'Publish Security Analysis Logs'
-
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
-  displayName: Check SDL results
-  inputs:
-    AllTools: true
-
-- task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
-  displayName: Clean up
-  condition: succeededOrFailed()
+              - task: PostAnalysis@2
+                displayName: Post Analysis
+                inputs:
+                  GdnBreakAllTools: false
+                  GdnBreakGdnToolApiScan: true
+                
+              - task: TSAUpload@2
+                displayName: Upload APIScan results to TSA
+                inputs:
+                  GdnPublishTsaOnboard: false
+                  GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\.config\tsaoptions.json'
+                  GdnPublishTsaExportedResultsPublishable: true
+                continueOnError: true
+                condition: succeededOrFailed()
+                enabled: true


### PR DESCRIPTION
Update compliance build to run API scan and log bugs. This ensures that all required SDL tools run weekly with our compliance runs and logs bugs.

I verified the compliance pipeline runs successfully and there are no compliance violations.