### PR TITLE
Enable PME signing and allow only real sign for the CI pipeline

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -13,6 +13,9 @@ trigger:
 
 pr: none
 
+variables:
+  SignType: Real
+
 resources:
   repositories:
     - repository: MicroBuildTemplate
@@ -49,6 +52,7 @@ extends:
                   enabled: true
                   signType: $(SignType)
                   zipSources: false
+                  signWithProd: true
             steps:
               - template: /build/build.yml@self
                 parameters:


### PR DESCRIPTION
## What/Why
We need to enable PME signing with the new rule enforcement (Real signing with PME Enforcement - June 30th 2025).

## How
1. Enable PME signing with `signWithProd: true`
2. Only allow real signs for the CI pipeline.

## Testing
Verified the stages can be configured in the topic branch (which indicates no errors in the pipeline).