### PR TITLE
Specify a valid docker project name

### DIFF
--- a/build/build.yml
+++ b/build/build.yml
@@ -7,6 +7,7 @@ parameters:
   Docker: false
   Sign: false
   PublishArtifactTemplate: /build/templates/1es-publish-task.yml@self
+  DockerProjectName: microsoft-vssetup-powershell
 
 steps:
 - pwsh: |
@@ -58,6 +59,7 @@ steps:
     inputs:
       dockerComposeFile: docker/docker-compose.yml
       action: Build services
+      projectName: ${{ parameters.DockerProjectName }}
     env:
       CONFIGURATION: ${{ parameters.BuildConfiguration }}
 
@@ -69,6 +71,7 @@ steps:
       serviceName: test
       containerCommand: -Command Invoke-Pester C:\Tests -EnableExit -OutputFile C:\Tests\Results.xml -OutputFormat NUnitXml
       detached: false
+      projectName: ${{ parameters.DockerProjectName }}
     env:
       CONFIGURATION: ${{ parameters.BuildConfiguration }}
 


### PR DESCRIPTION
## What/Why
While trying to check in https://github.com/microsoft/vssetup.powershell/pull/86, I discovered that there hasn't been any pipeline run in the past year and during then a new project name rule got enforced that would fail the build. 

```
invalid project name "microsoft/vssetup.powershell": must consist only of lowercase alphanumeric characters, hyphens, and underscores as well as start with a letter or number
```

## How
1. Specify a valid docker project name into `DockerCompose@0` task.

## Testing
Validated with a pipeline run. Verified the Build Image and Test steps passed, and the pipeline run succeeded.