### PR TITLE
Fix APIScan in the compliance pipeline

### DIFF
--- a/.vsts-compliance.yml
+++ b/.vsts-compliance.yml
@@ -92,11 +92,13 @@ extends:
                 displayName: Run APIScan
                 inputs:
                   softwareFolder: $(Build.StagingDirectory)\apiscan-inputs
-                  softwareName: 'Microsoft.VSConfigFinder'
+                  softwareName: 'VSSetup.PowerShell'
                   softwareVersionNum: '1'
                   toolVersion: Latest
+                  azureSubscription: VSEng-APIScanSC
                 env:
-                  AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId)
+                  AzureServicesAuthConnectionString: RunAs=App;AppId=$(ApiScanClientId);TenantId=72f988bf-86f1-41af-91ab-2d7cd011db47;ServiceConnectionId=93e24264-c5e6-4681-8175-ec8a41668480;
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
               - task: PublishSecurityAnalysisLogs@3
                 displayName: Publish 'SDLAnalysis-APIScan' artifact


### PR DESCRIPTION
## What?
Update the APIScan authentication configuration in the compliance pipeline to match the current auth pattern.

## Why?
The compliance pipeline was failing at the APIScan step because the old auth format (runAs=App;AppId=...) no longer works. The managed identity credential could not be acquired, resulting in "Identity not found" errors.

## How?
Updated vsts-compliance.yml to align with the working Setup-Engine-Compliance pipeline:

   - Added azureSubscription: VSEng-APIScanSC service connection input
   - Extended AzureServicesAuthConnectionString with TenantId and ServiceConnectionId
   - Added SYSTEM_ACCESSTOKEN: $(System.AccessToken) environment variable

## Testing?
- [x] Verified the compliance pipeline passes at the APIScan step

## Screenshots (optional)
<img width="307" height="370" alt="image" src="https://github.com/user-attachments/assets/3f9aab19-8b2c-4514-86de-bb6a28157963" />

