### PR TITLE
Update build dependencies

### DIFF
--- a/build/build.yml
+++ b/build/build.yml
@@ -54,7 +54,7 @@ steps:
 
 - ${{ if eq(parameters.Docker, 'true') }}:
   # Make sure service images are rebuilt if Dockerfiles changed.
-  - task: DockerCompose@0
+  - task: DockerCompose@1
     displayName: Build images
     inputs:
       dockerComposeFile: docker/docker-compose.yml
@@ -63,7 +63,7 @@ steps:
     env:
       CONFIGURATION: ${{ parameters.BuildConfiguration }}
 
-  - task: DockerCompose@0
+  - task: DockerCompose@1
     displayName: Runtime tests
     inputs:
       dockerComposeFile: docker/docker-compose.yml

--- a/docker/docker-compose.debug.yml
+++ b/docker/docker-compose.debug.yml
@@ -1,7 +1,6 @@
 # Copyright (C) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT license. See LICENSE.txt in the project root for license information.
 
-version: "2.1"
 services:
   test:
     image: microsoft/vssetup:debug

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,6 @@
 # Copyright (C) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT license. See LICENSE.txt in the project root for license information.
 
-version: "2.1"
 services:
   test:
     build: .

--- a/src/VSSetup.PowerShell/VSSetup.PowerShell.csproj
+++ b/src/VSSetup.PowerShell/VSSetup.PowerShell.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" version="1.0.0" />
     <PackageReference Include="Microsoft.PowerShell.2.ReferenceAssemblies" version="1.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" version="1.11.2290" />
-    <PackageReference Include="Nerdbank.GitVersioning" version="2.3.186" />
+    <PackageReference Include="Nerdbank.GitVersioning" version="3.9.50" />
     <PackageReference Include="StyleCop.Analyzers" version="1.1.118" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
   </ItemGroup>

--- a/test/VSSetup.PowerShell.Test/VSSetup.PowerShell.Test.csproj
+++ b/test/VSSetup.PowerShell.Test/VSSetup.PowerShell.Test.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.PowerShell.2.ReferenceAssemblies" version="1.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" version="1.11.2290" />
     <PackageReference Include="Moq" version="4.5.30" />
-    <PackageReference Include="Nerdbank.GitVersioning" version="2.3.186" />
+    <PackageReference Include="Nerdbank.GitVersioning" version="3.9.50" />
     <PackageReference Include="StyleCop.Analyzers" version="1.1.118" />
     <PackageReference Include="xunit" version="2.1.0" />
     <PackageReference Include="xunit.abstractions" version="2.0.0" />

--- a/test/VSSetup.PowerShell.Test/packages.config
+++ b/test/VSSetup.PowerShell.Test/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.PowerShell.2.ReferenceAssemblies" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Setup.Configuration.Interop" version="1.11.2290" targetFramework="net45" />
   <package id="Moq" version="4.5.30" targetFramework="net45" requireReinstallation="true" />
-  <package id="Nerdbank.GitVersioning" version="2.3.186" targetFramework="net451" developmentDependency="true" />
+  <package id="Nerdbank.GitVersioning" version="3.9.50" targetFramework="net451" developmentDependency="true" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net451" developmentDependency="true" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />


### PR DESCRIPTION
The NBGV we were using was very old, and DockerCompose@0 was deprecated, so this PR just pulls us forward to the latest supported versions of these dependencies.

Latest Docker Compose versions removed support for the 'version' property, so I also removed that from our Docker-Compose.yml files to avoid additional build warnings.