### PR TITLE
Enable the 1ES network isolation policy

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -26,6 +26,8 @@ resources:
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2
     pool:
       name: VSEngSS-MicroBuild2022-1ES
     sdl:

--- a/.vsts-compliance.yml
+++ b/.vsts-compliance.yml
@@ -39,6 +39,8 @@ resources:
 extends:
   template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2
     pool:
       name: VSEngSS-MicroBuild2022-1ES
     sdl:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,7 @@ If you add any commands please update the `Tags` property of the _VSSetup.nuproj
 
 ## Documentation
 
-Cmdlet and `about_` help is authored as markdown under _docs\VSSetup_ and compiled into PowerShell help artifacts (_Microsoft.VisualStudio.Setup.PowerShell.dll-Help.xml_ and _about_VSSetup.help.txt_) using [platyPS][platyps].
-
-Because the official build runs under network isolation and cannot reach the PowerShell Gallery, these artifacts are **checked in** under _src\VSSetup.PowerShell\help_ and copied to the build output by the project rather than generated during the build. If you change any markdown under _docs\VSSetup_, regenerate and commit the artifacts locally:
+Cmdlet and `about_` help is authored as markdown under _docs\VSSetup_ and compiled into the checked-in help artifacts under _src\VSSetup.PowerShell\help_. If you change any markdown under _docs\VSSetup_, regenerate these artifacts and check the updated output files in as part of the same pull request:
 
 ```powershell
 Install-Module -Name platyPS -Scope CurrentUser -Force
@@ -107,4 +105,3 @@ Thank you for your contributions!
   [samples]: https://aka.ms/setup/configuration/samples
   [docs]: https://aka.ms/setup/configuration/docs
   [interop]: https://aka.ms/setup/configuration/interop
-  [platyps]: https://github.com/PowerShell/platyPS

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ If you add any commands please update the `Tags` property of the _VSSetup.nuproj
 Cmdlet and `about_` help is authored as markdown under _docs\VSSetup_ and compiled into the checked-in help artifacts under _src\VSSetup.PowerShell\help_. If you change any markdown under _docs\VSSetup_, regenerate these artifacts and check the updated output files in as part of the same pull request:
 
 ```powershell
-Install-Module -Name platyPS -Scope CurrentUser -Force
+Install-Module -Name platyPS -Scope CurrentUser
 build\Update-Help.ps1
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,17 @@ Code analysis and style cop rules are defined for this solution, but are current
 
 If you add any commands please update the `Tags` property of the _VSSetup.nuproj_ project as appropriate. This project is used instead of `Publish-Module` from the _PowerShellGet_ module because it works better with the build systems and can be tested on developer machines without also publishing.
 
+## Documentation
+
+Cmdlet and `about_` help is authored as markdown under _docs\VSSetup_ and compiled into PowerShell help artifacts (_Microsoft.VisualStudio.Setup.PowerShell.dll-Help.xml_ and _about_VSSetup.help.txt_) using [platyPS][platyps].
+
+Because the official build runs under network isolation and cannot reach the PowerShell Gallery, these artifacts are **checked in** under _src\VSSetup.PowerShell\help_ and copied to the build output by the project rather than generated during the build. If you change any markdown under _docs\VSSetup_, regenerate and commit the artifacts locally:
+
+```powershell
+Install-Module -Name platyPS -Scope CurrentUser -Force
+build\Update-Help.ps1
+```
+
 ## Building
 
 Before you can build this project from the command line with MSBuild or within Visual Studio, you must restore packages including the [embeddable interop types][interop].
@@ -96,3 +107,4 @@ Thank you for your contributions!
   [samples]: https://aka.ms/setup/configuration/samples
   [docs]: https://aka.ms/setup/configuration/docs
   [interop]: https://aka.ms/setup/configuration/interop
+  [platyps]: https://github.com/PowerShell/platyPS

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="Setup-Dependencies" value="https://devdiv.pkgs.visualstudio.com/_packaging/Setup-Dependencies/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="Setup-Dependencies" value="https://devdiv.pkgs.visualstudio.com/_packaging/Setup-Dependencies/nuget/v3/index.json" />
+    <add key="Setup-Dependencies" value="https://pkgs.dev.azure.com/azure-public/vssetup/_packaging/Setup-Dependencies/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/build/Update-Help.ps1
+++ b/build/Update-Help.ps1
@@ -26,7 +26,7 @@ $docsPath = Join-Path $repoRoot 'docs\VSSetup'
 $outputPath = Join-Path $repoRoot 'src\VSSetup.PowerShell\help'
 
 if (-not (Get-Module -ListAvailable -Name platyPS)) {
-    throw "platyPS is not installed. Run: Install-Module -Name platyPS -Scope CurrentUser -Force"
+    throw "platyPS is not installed. Run: Install-Module -Name platyPS -Scope CurrentUser"
 }
 
 Import-Module platyPS

--- a/build/Update-Help.ps1
+++ b/build/Update-Help.ps1
@@ -14,7 +14,7 @@
 
 .NOTES
     Requires the platyPS module. Install it locally with:
-        Install-Module -Name platyPS -Scope CurrentUser -Force
+        Install-Module -Name platyPS -Scope CurrentUser
 #>
 [CmdletBinding()]
 param()

--- a/build/Update-Help.ps1
+++ b/build/Update-Help.ps1
@@ -1,0 +1,40 @@
+<#
+.SYNOPSIS
+    Regenerates the checked-in PowerShell help artifacts from the markdown docs.
+
+.DESCRIPTION
+    The official build runs under 1ES network isolation and cannot reach the
+    PowerShell Gallery, so it no longer installs platyPS or runs New-ExternalHelp.
+    Instead, the generated help artifacts are checked in under
+    src\VSSetup.PowerShell\help and copied to the build output by the project.
+
+    Run this script locally (outside the isolated build) whenever the cmdlet or
+    about_ markdown files under docs\VSSetup change, then commit the regenerated
+    files under src\VSSetup.PowerShell\help.
+
+.NOTES
+    Requires the platyPS module. Install it locally with:
+        Install-Module -Name platyPS -Scope CurrentUser -Force
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$docsPath = Join-Path $repoRoot 'docs\VSSetup'
+$outputPath = Join-Path $repoRoot 'src\VSSetup.PowerShell\help'
+
+if (-not (Get-Module -ListAvailable -Name platyPS)) {
+    throw "platyPS is not installed. Run: Install-Module -Name platyPS -Scope CurrentUser -Force"
+}
+
+Import-Module platyPS
+
+if (-not (Test-Path -Path $outputPath)) {
+    $null = New-Item -Path $outputPath -ItemType Directory
+}
+
+New-ExternalHelp -Path $docsPath -OutputPath $outputPath -Force | Out-Null
+
+Write-Host "Regenerated help artifacts in $outputPath. Review and commit the changes."

--- a/build/build.yml
+++ b/build/build.yml
@@ -10,6 +10,9 @@ parameters:
   DockerProjectName: microsoft-vssetup-powershell
 
 steps:
+- task: NuGetAuthenticate@1
+  displayName: Authenticate to Azure Artifacts
+
 - pwsh: |
     dotnet tool install --tool-path "${env:AGENT_TOOLSDIRECTORY}\nbgv" `
      --configfile "$(Build.SourcesDirectory)\NuGet.config" nbgv

--- a/build/build.yml
+++ b/build/build.yml
@@ -11,7 +11,8 @@ parameters:
 
 steps:
 - pwsh: |
-    dotnet tool install --tool-path "${env:AGENT_TOOLSDIRECTORY}\nbgv" nbgv
+    dotnet tool install --tool-path "${env:AGENT_TOOLSDIRECTORY}\nbgv" `
+     --configfile "$(Build.SourcesDirectory)\NuGet.config" nbgv
     $version = & "${env:AGENT_TOOLSDIRECTORY}\nbgv\nbgv.exe" get-version --variable SemVer1
     & "${env:AGENT_TOOLSDIRECTORY}\nbgv\nbgv.exe" cloud --version $version
   displayName: Set cloud build version
@@ -21,6 +22,9 @@ steps:
 
 - task: NuGetCommand@2
   displayName: Restore nuget packages
+  inputs:
+    feedsToUse: config
+    nugetConfigPath: $(Build.SourcesDirectory)\NuGet.config
 
 - pwsh: |
     Install-Module -Name platyPS -Repository PSGallery -SkipPublisherCheck -Force
@@ -115,6 +119,8 @@ steps:
     displayName: Restore nuget packages
     inputs:
       restoreSolution: $(Build.SourcesDirectory)\pkg\VSSetup\VSSetup.signproj
+      feedsToUse: config
+      nugetConfigPath: $(Build.SourcesDirectory)\NuGet.config
 
   - task: VSBuild@1
     displayName: Sign packages

--- a/build/build.yml
+++ b/build/build.yml
@@ -29,17 +29,6 @@ steps:
     feedsToUse: config
     nugetConfigPath: $(Build.SourcesDirectory)\NuGet.config
 
-- pwsh: |
-    Install-Module -Name platyPS -Repository PSGallery -SkipPublisherCheck -Force
-  displayName: Install PowerShell modules
-
-- pwsh: |
-    New-ExternalHelp -Path docs\VSSetup -OutputPath "src\VSSetup.PowerShell\bin\${env:CONFIGURATION}" -Force
-  displayName: Compile documentation
-  env:
-    CONFIGURATION: ${{ parameters.BuildConfiguration }}
-  workingDirectory: $(Build.SourcesDirectory)
-
 - task: VSBuild@1
   displayName: Build solution
   inputs:

--- a/src/VSSetup.PowerShell/VSSetup.PowerShell.csproj
+++ b/src/VSSetup.PowerShell/VSSetup.PowerShell.csproj
@@ -36,6 +36,14 @@
     <Content Include="VSSetup.psm1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="help\Microsoft.VisualStudio.Setup.PowerShell.dll-Help.xml">
+      <Link>%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="help\about_VSSetup.help.txt">
+      <Link>%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Template Include="VSSetup.psd1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/VSSetup.PowerShell/VSSetup.PowerShell.csproj
+++ b/src/VSSetup.PowerShell/VSSetup.PowerShell.csproj
@@ -6,7 +6,6 @@
     <RootNamespace>Microsoft.VisualStudio.Setup</RootNamespace>
     <AssemblyName>Microsoft.VisualStudio.Setup.PowerShell</AssemblyName>
     <TargetFramework>net462</TargetFramework>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>Visual Studio Setup PowerShell Module</AssemblyTitle>
@@ -35,14 +34,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="VSSetup.psm1">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="help\Microsoft.VisualStudio.Setup.PowerShell.dll-Help.xml">
-      <Link>%(Filename)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="help\about_VSSetup.help.txt">
-      <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Template Include="VSSetup.psd1" />
@@ -74,6 +65,14 @@
         <Authenticode>Microsoft400</Authenticode>
       </FilesToSign>
     </ItemGroup>
+  </Target>
+
+  <!-- Place the checked-in help artifacts alongside LICENSE in bin\$(Configuration) so the
+       Archive and pack steps pick them up, matching the old New-ExternalHelp output location. -->
+  <Target Name="CopyHelpArtifacts" AfterTargets="Build">
+    <Copy SourceFiles="help\Microsoft.VisualStudio.Setup.PowerShell.dll-Help.xml;help\about_VSSetup.help.txt"
+          DestinationFolder="$(MSBuildProjectDirectory)\bin\$(Configuration)"
+          SkipUnchangedFiles="true" />
   </Target>
 
 </Project>

--- a/src/VSSetup.PowerShell/VSSetup.PowerShell.csproj
+++ b/src/VSSetup.PowerShell/VSSetup.PowerShell.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Microsoft.VisualStudio.Setup</RootNamespace>
     <AssemblyName>Microsoft.VisualStudio.Setup.PowerShell</AssemblyName>
     <TargetFramework>net462</TargetFramework>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>Visual Studio Setup PowerShell Module</AssemblyTitle>

--- a/src/VSSetup.PowerShell/help/Microsoft.VisualStudio.Setup.PowerShell.dll-Help.xml
+++ b/src/VSSetup.PowerShell/help/Microsoft.VisualStudio.Setup.PowerShell.dll-Help.xml
@@ -1,0 +1,379 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<helpItems schema="maml" xmlns="http://msh">
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Get-VSSetupInstance</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>VSSetupInstance</command:noun>
+      <maml:description>
+        <maml:para>Enumerates instances of Visual Studio and related products.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Enumerates instances of Visual Studio and related products. By default, instances with fatal errors are not returned by you can pass `-All` to enumerate them as well.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Get-VSSetupInstance</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>All</maml:name>
+          <maml:description>
+            <maml:para>Enumerate all instances of Visual Studio - even those with fatal errors.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Prerelease</maml:name>
+          <maml:description>
+            <maml:para>Also show prereleases / previews. By default, only releases are shown.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Get-VSSetupInstance</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="PSPath">
+          <maml:name>LiteralPath</maml:name>
+          <maml:description>
+            <maml:para>The path to the product installation directory. Wildcards are not supported.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Get-VSSetupInstance</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="0" aliases="none">
+          <maml:name>Path</maml:name>
+          <maml:description>
+            <maml:para>The path to the product installation directory. Wildcards are supported.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>All</maml:name>
+        <maml:description>
+          <maml:para>Enumerate all instances of Visual Studio - even those with fatal errors.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="PSPath">
+        <maml:name>LiteralPath</maml:name>
+        <maml:description>
+          <maml:para>The path to the product installation directory. Wildcards are not supported.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="0" aliases="none">
+        <maml:name>Path</maml:name>
+        <maml:description>
+          <maml:para>The path to the product installation directory. Wildcards are supported.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Prerelease</maml:name>
+        <maml:description>
+          <maml:para>Also show prereleases / previews. By default, only releases are shown.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String[]</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para>One or more paths to product installation directories.</maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>Microsoft.VisualStudio.Setup.Instance</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para>Information about each instance enumerated.</maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Get-VSSetupInstance -All</dev:code>
+        <dev:remarks>
+          <maml:para>Enumerates all instances of Visual Studio and related products even if a fatal error was raised during the last operation.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- Example 2 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Get-VSSetupInstance 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community'</dev:code>
+        <dev:remarks>
+          <maml:para>Gets the instance for the product installed to the given directory.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://github.com/Microsoft/vssetup.powershell/raw/master/docs/VSSetup/Get-VSSetupInstance.md</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Select-VSSetupInstance</command:name>
+      <command:verb>Select</command:verb>
+      <command:noun>VSSetupInstance</command:noun>
+      <maml:description>
+        <maml:para>Selects instances of Visual Studio and related products based on criteria.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>You can specify zero or more products (by default, Visual Studio Community, Professional, and Enterprise are selected) to find, along with zero or more workloads that all are required by any instances enumerated. Additionally, you can specify a version range to limit the results or request the latest instance. All criteria are combined to return the best instance or instances for your needs.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Select-VSSetupInstance</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="0" aliases="none">
+          <maml:name>Instance</maml:name>
+          <maml:description>
+            <maml:para>One or more instances from which to select.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Instance[]</command:parameterValue>
+          <dev:type>
+            <maml:name>Instance[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Latest</maml:name>
+          <maml:description>
+            <maml:para>Select the most recently installed instance with the highest version (within the optional `-Version` range).</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Product</maml:name>
+          <maml:description>
+            <maml:para>One or more products to select. Wildcards are supported.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>Microsoft.VisualStudio.Product.Community, Microsoft.VisualStudio.Product.Professional, Microsoft.VisualStudio.Product.Enterprise</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Require</maml:name>
+          <maml:description>
+            <maml:para>One or more workloads or components to select. All requirements specified must be met. Wildcards are not supported.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>RequireAny</maml:name>
+          <maml:description>
+            <maml:para>Change the behavior of -Require such that any one or more requirements specified must be met.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Version</maml:name>
+          <maml:description>
+            <maml:para>A version range to limit results. A single version like '15.0' is equivalent to '[15.0,)', which means versions 15.0 and newer are in range. You can also specify versions like '[15.0,16.0)' to limit results to Visual Studio 2017 only (15.x).</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="0" aliases="none">
+        <maml:name>Instance</maml:name>
+        <maml:description>
+          <maml:para>One or more instances from which to select.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Instance[]</command:parameterValue>
+        <dev:type>
+          <maml:name>Instance[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Latest</maml:name>
+        <maml:description>
+          <maml:para>Select the most recently installed instance with the highest version (within the optional `-Version` range).</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Product</maml:name>
+        <maml:description>
+          <maml:para>One or more products to select. Wildcards are supported.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>Microsoft.VisualStudio.Product.Community, Microsoft.VisualStudio.Product.Professional, Microsoft.VisualStudio.Product.Enterprise</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Require</maml:name>
+        <maml:description>
+          <maml:para>One or more workloads or components to select. All requirements specified must be met. Wildcards are not supported.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>RequireAny</maml:name>
+        <maml:description>
+          <maml:para>Change the behavior of -Require such that any one or more requirements specified must be met.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Version</maml:name>
+        <maml:description>
+          <maml:para>A version range to limit results. A single version like '15.0' is equivalent to '[15.0,)', which means versions 15.0 and newer are in range. You can also specify versions like '[15.0,16.0)' to limit results to Visual Studio 2017 only (15.x).</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>Microsoft.VisualStudio.Setup.Instance[]</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para>One or more instances from which to select.</maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>Microsoft.VisualStudio.Setup.Instance</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para>Zero or more instances that met specified criteria.</maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Get-VSSetupInstance | Select-VSSetupInstance -Latest</dev:code>
+        <dev:remarks>
+          <maml:para>Select the most-recently installed instance of the highest version of Visual Studio Community, Professional, or Enterprise installed.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- Example 2 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Get-VSSetupInstance | Select-VSSetupInstance -Product * -Require 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64'</dev:code>
+        <dev:remarks>
+          <maml:para>Selects any product with the native Visual C++ compilers installed.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://github.com/Microsoft/vssetup.powershell/raw/master/docs/VSSetup/Select-VSSetupInstance.md</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+</helpItems>

--- a/src/VSSetup.PowerShell/help/about_VSSetup.help.txt
+++ b/src/VSSetup.PowerShell/help/about_VSSetup.help.txt
@@ -1,0 +1,46 @@
+﻿TOPIC
+    about_vssetup
+
+SHORT DESCRIPTION
+    Enumerate and select instances of Visual Studio.
+
+LONG DESCRIPTION
+    Visual Studio 2017 introduced a new setup engine capable of installing
+    multiple instances of Visual Studio and other products in the Visual Studio
+    family. This module provides commands to enumerate those instances and
+    select instances that meet your criteria. For example, in a development
+    environment you might have a script that finds an instance of Visual Studio
+    with the the Managed Desktop workload for writing projects targeting the
+    .NET Framework. See below for more examples.
+
+VARIABLES
+    You can get the version of this module or of the query API the module uses
+    from the `$VSSetupVersionTable` variable.
+
+    PS> $VSSetupVersionTable
+    
+    Name                           Value
+    ----                           -----
+    QueryVersion                   1.15.23.19330
+    ModuleVersion                  2.1.2.4917
+
+EXAMPLES
+    You can enumerate all instances - even those with errors that require a
+    repair - with the following command.
+
+    Get-VSSetupInstance -All
+
+    If you want to select all launchable instances of Visual Studio products
+    that have the Managed Desktop workload, use the following command.
+
+    Get-VSSetupInstance | Get-VSSetupInstance `
+        -Require 'Microsoft.VisualStudio.Workload.ManagedDesktop'
+
+    You can also get the instance for an installation directory if you want to
+    discover more about what is installed to that directory.
+
+    Get-VSSetupInstance 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community'
+
+SEE ALSO
+    https://github.com/Microsoft/vssetup.powershell
+


### PR DESCRIPTION
##What
Enable the 1ES network isolation policy on the build and remove the PowerShell Gallery dependency by checking in the help artifacts instead of generating them with platyPS at build time.

##Why
SFI requires builds to use only approved internal feeds.

##How
Checked in Nuget.Config to use internal feed and stopped using powershell module to generate help files. Instead, have users run script to regenerate them when docs\VSSetup changes. The script runs what build.yml used to do.